### PR TITLE
Visible chars are now a parameter in onTyped

### DIFF
--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -56,7 +56,7 @@ class TypeWriter extends React.Component {
         nextToken = componentTokenAt(this, this.state.visibleChars);
 
     if (token && onTyped) {
-      onTyped(token);
+      onTyped(token, prevState.visibleChars);
     }
 
     // check the delay map for additional delays at the index.


### PR DESCRIPTION
I have been in the situation where `token` alone is not enough in the `onTyped` callback. This happens when there are multiple occurrences of the same token in the text that's going to be displayed.

With this pull request, the value of `prevState.visibleChars` is available as the second parameter in the callback, making it easier to make assumptions based on the token and the position.
