### PR TITLE
Update react external configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,12 @@ module.exports = {
     extensions: ['.js', '.jsx']
   },
   externals: {
-    react: 'React'
+    react: {
+      root: 'React',
+      amd: 'react',
+      commonjs: 'react',
+      commonjs2: 'react'
+    }
   },
   output: {
     path: './build',


### PR DESCRIPTION
This updates the configuration, so the React module name matches if it's not a global module. In case sensitive environments, the compiled module will not produce an error any more. For reference, this is the same configuration as used in `react-router`.
