### PR TITLE
Update compatibility for React 0.14

### DIFF
--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -153,6 +153,4 @@ TypeWriter.defaultProps = {
 
 };
 
-TypeWriter.displayName = 'TypeWriter';
-
 export default TypeWriter;


### PR DESCRIPTION
React 0.14 does not want a display name attached to it and does not see it as a valid component. The Babel React transformer should also append the display name if needed.

@ianbjorndilling Let me know if I should prepare a release for this. (Bump the minor package version, tagging the release and publishing to NPM)
