### PR TITLE
[WIP] Rollup build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "0.2.1",
   "description": "React components for automatic typing effects.",
   "main": "./build/react-typewriter.js",
+  "jsnext:main": "./build/react-typewriter.es2015.js",
   "scripts": {
     "prepublish": "npm run build",
-    "build": "./node_modules/.bin/webpack -p",
+    "build": "rollup-babel-lib-bundler --module-name TypeWriter -d build ./src/index.js",
     "dev-build": "./node_modules/.bin/webpack -d --progress --colors",
     "watch-build": "./node_modules/.bin/webpack -d --watch --progress --colors",
     "dev-server": "./node_modules/.bin/webpack-dev-server --port 3000",
@@ -32,11 +33,13 @@
     "babel-loader": "^6.2.3",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
+    "babel-preset-es2015-rollup": "^1.1.1",
     "babel-preset-react": "^6.5.0",
     "eslint": "^0.24.0",
     "eslint-plugin-react": "^2.6.4",
     "node-libs-browser": "^0.5.2",
     "react-hot-loader": "^1.2.7",
+    "rollup-babel-lib-bundler": "^2.1.1",
     "webpack": "^1.10.0",
     "webpack-dev-server": "^1.10.1"
   }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
     "react": "^0.13.3"
   },
   "devDependencies": {
-    "babel": "^5.6.14",
-    "babel-core": "^5.6.15",
+    "babel-core": "^6.5.2",
     "babel-eslint": "^3.1.20",
-    "babel-loader": "^5.2.2",
+    "babel-loader": "^6.2.3",
+    "babel-plugin-transform-object-rest-spread": "^6.5.0",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
     "eslint": "^0.24.0",
     "eslint-plugin-react": "^2.6.4",
     "node-libs-browser": "^0.5.2",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015-rollup", "react"],
+  "plugins": ["transform-object-rest-spread"]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import TypeWriter from './components/TypeWriter';
+import TypeWriter from './components/TypeWriter.jsx';
 
 export default TypeWriter;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
     loaders: [{
       test: /\.jsx?$/,
       exclude: /(node_modules)/,
-      loader: 'babel?stage=1'
+      loader: 'babel?presets[]=react,presets[]=es2015,plugins[]=transform-object-rest-spread'
     }]
   }
 };


### PR DESCRIPTION
This requires #7 to be merged in first.

This builds TypeWriter using Rollup.

Major changes:
- Smaller bundle
- Default file is the CommonJS one, UMD has `.umd.js`
- Support for `jsnext:main`

Caveats:
- `.jsx` file needed to be loaded explicitly
