### PR TITLE
Start typing when typing prop is changed from 0 to 1 as well, not only when the prop is changed from -1 to 1

### DIFF
--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -35,7 +35,7 @@ class TypeWriter extends React.Component {
       this.setState({
         visibleChars: this.state.visibleChars - 1
       });
-    } else if (active < 0 && next > 0) {
+    } else if (active <= 0 && next > 0) {
       this.setState({
         visibleChars: this.state.visibleChars + 1
       });


### PR DESCRIPTION
Currently the typing starts only when the typing prop is either initially set to 1, or when it is changed from -1 to 1. This pull requests allows it to start typing when the typing prop is changed from 0 to 1 as well.
