### PR TITLE
Fix bug in componentShouldUpdate causing the component never to update when children are strings and have changed

### DIFF
--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -39,7 +39,7 @@ class TypeWriter extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const children = this.props;
+    const { children } = this.props;
     const nextChildren = nextProps.children;
     const childrenAreStrings = typeof children === 'string' && typeof nextChildren === 'string';
     // TODO Implement childrenChanged for non-string children as well


### PR DESCRIPTION
@frostney, I'm sorry, just found out i made a mistake in my previous pull request: https://github.com/ianbjorndilling/react-typewriter/pull/13. Causing `componentShouldUpdate` never to return `true` when `children` is a `string` and has changed.
