### PR TITLE
Change container element to a div instead of span since span can not have all elements as children according to W3C

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ Here, `World!` will be stamped onto the page instead of typed out:
 </TypeWriter>
 ```
 
+### props.container
+
+type: `String`
+default: `span`
+
+The can be used to determine the component to be used as a container for `react-typewriter`.
+
 ### refs.reset
 
 type: `Function`

--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -1,6 +1,30 @@
 import React from 'react';
 import {styleComponentSubstring, componentTokenAt} from '../utils';
 
+const propTypes = {
+  fixed: React.PropTypes.bool,
+  delayMap: React.PropTypes.arrayOf(React.PropTypes.shape({
+    at: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number,
+      React.PropTypes.instanceOf(RegExp)
+    ]),
+    delay: React.PropTypes.number
+  })),
+  typing(props, propName) {
+    const prop = props[propName];
+
+    if (!(Number(prop) === prop && prop % 1 === 0) || (prop < -1 || prop > 1)) {
+      return new Error('typing property must be an integer between 1 and -1');
+    }
+  },
+  maxDelay: React.PropTypes.number,
+  minDelay: React.PropTypes.number,
+  onTypingEnd: React.PropTypes.func,
+  onTyped: React.PropTypes.func,
+  container: React.PropTypes.string
+};
+
 /**
  * TypeWriter
  */
@@ -93,19 +117,24 @@ class TypeWriter extends React.Component {
   }
 
   render() {
-    const {
+    let {
       children,
       fixed,
       container,
-      ...props
+      ...otherProps
     } = this.props;
     const {
       visibleChars
     } = this.state;
 
     const Container = container;
-    const containerComponent = <Container {...props}>{children}</Container>;
     const hideStyle = fixed ? {visibility: 'hidden'} : {display: 'none'};
+
+    for (let key of Object.keys(propTypes)) {
+      delete otherProps[key];
+    }
+
+    const containerComponent = <Container {...otherProps}>{children}</Container>;
 
     return styleComponentSubstring(containerComponent, hideStyle, visibleChars);
   }
@@ -120,29 +149,7 @@ class TypeWriter extends React.Component {
   }
 }
 
-TypeWriter.propTypes = {
-  fixed: React.PropTypes.bool,
-  delayMap: React.PropTypes.arrayOf(React.PropTypes.shape({
-    at: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.instanceOf(RegExp)
-    ]),
-    delay: React.PropTypes.number
-  })),
-  typing(props, propName) {
-    const prop = props[propName];
-
-    if (!(Number(prop) === prop && prop % 1 === 0) || (prop < -1 || prop > 1)) {
-      return new Error('typing property must be an integer between 1 and -1');
-    }
-  },
-  maxDelay: React.PropTypes.number,
-  minDelay: React.PropTypes.number,
-  onTypingEnd: React.PropTypes.func,
-  onTyped: React.PropTypes.func,
-  container: React.PropTypes.string
-};
+TypeWriter.propTypes = propTypes;
 
 TypeWriter.defaultProps = {
   typing: 0,

--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -96,15 +96,18 @@ class TypeWriter extends React.Component {
     const {
       children,
       fixed,
+      container,
       ...props
     } = this.props;
     const {
       visibleChars
     } = this.state;
-    const container = <div {...props}>{children}</div>;
+
+    const Container = container;
+    const containerComponent = <Container {...props}>{children}</Container>;
     const hideStyle = fixed ? {visibility: 'hidden'} : {display: 'none'};
 
-    return styleComponentSubstring(container, hideStyle, visibleChars);
+    return styleComponentSubstring(containerComponent, hideStyle, visibleChars);
   }
 
   _handleTimeout() {
@@ -137,13 +140,15 @@ TypeWriter.propTypes = {
   maxDelay: React.PropTypes.number,
   minDelay: React.PropTypes.number,
   onTypingEnd: React.PropTypes.func,
-  onTyped: React.PropTypes.func
+  onTyped: React.PropTypes.func,
+  container: React.PropTypes.string
 };
 
 TypeWriter.defaultProps = {
   typing: 0,
   maxDelay: 100,
-  minDelay: 20
+  minDelay: 20,
+  container: 'span'
 };
 
 export default TypeWriter;

--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -101,7 +101,7 @@ class TypeWriter extends React.Component {
     const {
       visibleChars
     } = this.state;
-    const container = <span {...props}>{children}</span>;
+    const container = <div {...props}>{children}</div>;
     const hideStyle = fixed ? {visibility: 'hidden'} : {display: 'none'};
 
     return styleComponentSubstring(container, hideStyle, visibleChars);


### PR DESCRIPTION
W3C threw me an error when having a `<p>` element inside `react-typewriter` so I'd like to propose to change the container to be a `<div>` since it may have any element as a child.
