### PR TITLE
Resolve error when pre-rendering react on server-side

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@ export var styleComponentSubstring = (() => {
 
       if (_index >= _start && (!_end || _index < _end)) {
         cloneProps = {
-          style: React.addons.update(style || {}, {$merge: _styles})
+          style: Object.assign(style || {}, _styles)
         };
       }
       _index++;


### PR DESCRIPTION
Hello,

When I try to use `react-typewriter` stamps in my stack that pre-renders the `React` on the server-side, I get the following error:

```
TypeError: Cannot read property 'update' of undefined
[1]     at e (/Users/user/myapp/node_modules/react-typewriter/build/react-typewriter.js:1:4647)
[1]     at t (/Users/user/myapp/node_modules/react-typewriter/build/react-typewriter.js:1:4802)
[1]     at mapSingleChildIntoContext (/Users/user/myapp/node_modules/react/lib/ReactChildren.js:105:26)
[1]     at traverseAllChildrenImpl (/Users/user/myapp/node_modules/react/lib/traverseAllChildren.js:98:5)
[1]     at traverseAllChildrenImpl (/Users/user/myapp/node_modules/react/lib/traverseAllChildren.js:114:23)
[1]     at traverseAllChildren (/Users/user/myapp/node_modules/react/lib/traverseAllChildren.js:186:10)
[1]     at mapIntoWithKeyPrefixInternal (/Users/user/myapp/node_modules/react/lib/ReactChildren.js:125:3)
[1]     at Object.mapChildren [as map] (/Users/user/myapp/node_modules/react/lib/ReactChildren.js:145:3)
[1]     at e (/Users/user/myapp/node_modules/react-typewriter/build/react-typewriter.js:1:4714)
[1]     at /Users/user/myapp/node_modules/react-typewriter/build/react-typewriter.js:1:5103
```

I resolved this error by changing line 22 in `src/utils.js` from `React.addons.update(style || {}, {$merge: _styles})` to `Object.assign(style || {}, _styles)` as it seemed that `React.addons` was `undefined` and pre-rendering and using `Object.assign` avoided this issue altogether.
