### PR TITLE
Add onTypingStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ default: `0`
 
 A value of 1 will cause the component type text left to right until completion. A value of -1 will cause the component to *erase* text right to left.
 
+#### props.onTypingStart
+
+type: `Boolean`
+default: `true`
+
+This value is a typing start Timing control. if the user set false fro this props initially,  
+when the value trun out to be false, typing starts.
+
 #### props.initDelay
 
 type: `Integer`

--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -16,7 +16,9 @@ class TypeWriter extends React.Component {
   }
 
   componentDidMount() {
-    this._timeoutId = setTimeout(this._handleTimeout, this.props.initDelay);
+    if (this.props.onTypingStart) {
+      this._timeoutId = setTimeout(this._handleTimeout, this.props.initDelay);
+    }
   }
 
   componentWillUnmount() {
@@ -26,6 +28,12 @@ class TypeWriter extends React.Component {
   componentWillReceiveProps(nextProps) {
     const next = nextProps.typing;
     const active = this.props.typing;
+    const nextOnTypingStart = nextProps.onTypingStart
+    const prevOnTypingStart = this.props.onTypingStart
+
+    if (nextOnTypingStart !== prevOnTypingStart) {
+      this._timeoutId = setTimeout(this._handleTimeout, this.props.initDelay);
+    }
 
     if (active > 0 && next < 0) {
       this.setState({
@@ -137,14 +145,16 @@ TypeWriter.propTypes = {
   maxDelay: React.PropTypes.number,
   minDelay: React.PropTypes.number,
   onTypingEnd: React.PropTypes.func,
-  onTyped: React.PropTypes.func
+  onTyped: React.PropTypes.func,
+  onTypingStart: React.PropTypes.bool
 };
 
 TypeWriter.defaultProps = {
   typing: 0,
   initDelay: 1000,
   maxDelay: 100,
-  minDelay: 20
+  minDelay: 20,
+  onTypingStart: true
 };
 
 export default TypeWriter;


### PR DESCRIPTION
@frostney  
Hi !
I'm a user about this repo. Thank you for making a great library!!

When i was using this typewriter component, i wanted to control typing start timing. 
Previously, some commiters added the initDelay props 
but i think it is not a simple way enough to control timing.

So, I add this onTypingStart props.
The default value is true, but if user set false to this props initially,
when the value trun out to be false, typing starts !!

if there is no problem, please merge this PR 🙇 

This is a sample code. 
```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8"/>
    <title>TypeWriter Demo</title>
  </head>
  <body>
    <h1>TypeWriter</h1>
    <div id="type-writer-container"></div>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react-with-addons.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react-dom.js"></script>
    <script src="http://fb.me/JSXTransformer-0.12.1.js"></script>
    <script src="./react-typewriter.js"></script>
    <script type="text/jsx">
      class Sample extends React.Component {
        constructor(props) {
          super(props);
          this.state = {
            onTypingStart: false
          }
        }
        render() {
          return (
            <div>
              <TypeWriter
                fixed
                onTypingStart={this.state.onTypingStart}
                typing={1}
                style={{ fontSize: 40 }}
              >
                Hello World!!
              </TypeWriter>
              <button onClick={() => this.setState({ onTypingStart: !this.state.onTypingStart })}>
                typing start!!
              </button>
            </div>
          );
        }
      }
      ReactDOM.render(
        React.createElement(Sample),
        document.getElementById('type-writer-container'));
    </script>
  </body>
</html>

```

This is demo.

![kapture 2018-10-04 at 23 36 39](https://user-images.githubusercontent.com/17228098/46481555-9645ae80-c82e-11e8-9d1a-099b7d6310bb.gif)
