### PR TITLE
Fix for reverse typing bug (Issue #31)

### DIFF
--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -110,9 +110,13 @@ class TypeWriter extends React.Component {
   _handleTimeout() {
     const {typing} = this.props;
     const {visibleChars} = this.state;
+    
+    let visible = visibleChars
+
+    if (visible < -1) visible = -1
 
     this.setState({
-      visibleChars: visibleChars + typing
+      visibleChars: visible + typing
     });
   }
 }

--- a/src/components/TypeWriter.jsx
+++ b/src/components/TypeWriter.jsx
@@ -28,10 +28,12 @@ class TypeWriter extends React.Component {
     const active = this.props.typing;
 
     if (active > 0 && next < 0) {
+      clearInterval(this._timeoutId);
       this.setState({
         visibleChars: this.state.visibleChars - 1
       });
     } else if (active <= 0 && next > 0) {
+      clearInterval(this._timeoutId);
       this.setState({
         visibleChars: this.state.visibleChars + 1
       });
@@ -103,20 +105,16 @@ class TypeWriter extends React.Component {
     } = this.state;
     const container = <span {...props}>{children}</span>;
     const hideStyle = fixed ? {visibility: 'hidden'} : {display: 'none'};
-
+    
     return styleComponentSubstring(container, hideStyle, visibleChars);
   }
 
   _handleTimeout() {
     const {typing} = this.props;
     const {visibleChars} = this.state;
-    
-    let visible = visibleChars
-
-    if (visible < -1) visible = -1
 
     this.setState({
-      visibleChars: visible + typing
+      visibleChars: visibleChars + typing
     });
   }
 }


### PR DESCRIPTION
Bug was caused by setting the `visibleChars` state twice when prop `typing`is changed.

Solution is to clear the `_handleTimeout` from running so that changing state won't fire twice.